### PR TITLE
Added update user score service for ASL and Bisindo

### DIFF
--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -17,6 +17,6 @@ router.put('/auth/change-email', verifyToken, authService.changeEmail);
 router.put('/auth/change-photo', verifyToken, upload.single('newPhoto'), authService.changePhotoProfile);
 router.get('/challenge/leaderboard', authService.getAllUserScores);
 router.get('/challenge/random-asl-sentence', aslService.getASLRandomSentences);
-router.put('/challenge/update-score', verifyToken, saveScoreService.updateScore);
+router.put('/challenge/update-asl-score', verifyToken, saveScoreService.updateASLScore);
 
 module.exports = router;

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -18,5 +18,6 @@ router.put('/auth/change-photo', verifyToken, upload.single('newPhoto'), authSer
 router.get('/challenge/leaderboard', authService.getAllUserScores);
 router.get('/challenge/random-asl-sentence', aslService.getASLRandomSentences);
 router.put('/challenge/update-asl-score', verifyToken, saveScoreService.updateASLScore);
+router.put('/challenge/update-bisindo-score', verifyToken, saveScoreService.updateBisindoScore);
 
 module.exports = router;

--- a/src/services/challenge/save-score-service.js
+++ b/src/services/challenge/save-score-service.js
@@ -6,14 +6,14 @@ const {
 const auth = getAuth();
 
 class UpdateScoreService {
-    async updateScore(req, res) {
+    async updateASLScore(req, res) {
         const user = auth.currentUser;
         if (!user) {
             return res.status(401).json({ error: "No user logged in" });
         }
 
         const { asl_score } = req.body;
-        if (!asl_score) {
+        if (!asl_score || asl_score === "0") {
             return res.status(400).json({ error: "Score is required" });
         }
         
@@ -32,7 +32,10 @@ class UpdateScoreService {
                 asl_score : newASLScore
             });
 
-            return res.status(200).json({ message: "Score saved successfully!" });
+            return res.status(200).json({ 
+                message: "Score saved successfully!",
+                new_asl_score: newASLScore
+            });
         } catch (error) {
             console.error("Error updating score:", error.message);
             res.status(500).json({ error: "Internal Server Error" })

--- a/src/services/challenge/save-score-service.js
+++ b/src/services/challenge/save-score-service.js
@@ -41,6 +41,42 @@ class UpdateScoreService {
             res.status(500).json({ error: "Internal Server Error" })
         }
     }
+
+    async updateBisindoScore(req, res) {
+        const user = auth.currentUser;
+        if (!user) {
+            return res.status(401).json({ error: "No user logged in" });
+        }
+
+        const { bisindo_score } = req.body;
+        if (!bisindo_score || bisindo_score === "0") {
+            return res.status(400).json({ error: "Score is required" });
+        }
+        
+        try {
+            const userRef = db.collection("users").doc(user.uid);
+            const userData = (await userRef.get()).data();
+
+            if (!userData) {
+                return res.status(404).json({ error: "User not found" });
+            }
+            
+            const oldBisindoScore = userData.bisindo_score;
+            const newBisindoScore = parseInt(bisindo_score) + parseInt(oldBisindoScore);
+
+            await userRef.update({
+                bisindo_score : newBisindoScore
+            });
+
+            return res.status(200).json({ 
+                message: "Score saved successfully!",
+                new_bisindo_score: newBisindoScore
+            });
+        } catch (error) {
+            console.error("Error updating score:", error.message);
+            res.status(500).json({ error: "Internal Server Error" })
+        }
+    }
 }
 
 module.exports = new UpdateScoreService();


### PR DESCRIPTION
In this pull request I implemented update user score for each ASL and Bisindo score.

- `/challenge/update-asl-score` success with number (integer and input)
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/9043446a-13ed-4fd1-99c4-e6ff228a713b)
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/1728da4c-cc58-47b3-85cf-a47dfcfdd726)

- `/challenge/update-asl-score` error when the request body is empty
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/f127c490-5c29-4f72-8959-3f2e0e901afa)
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/b33f8b46-c3c0-4305-94ae-984305ab1c01)
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/8a6d2075-33bf-4f18-913b-d7835104c231)

- `/challenge/update-asl-score` error when the user is not logged in
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/cbd1c2c3-9f6e-499c-aabc-37a6212cda08)

- `/challenge/update-bisindo-score` success with number (integer and string input)
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/2dcb07ea-02cb-4cac-8152-446b05d57fbd)
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/3fd7d13b-04b6-4f87-8829-a5c556c1a6cd)

- `/challenge/update-bisindo-score` error when the request body is empty
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/b21d3c65-0c6b-4d6e-9f80-51184594434a)
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/265be39c-a315-43d2-9334-7c723c796169)
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/84c4e591-f66a-4296-b6ce-199dd6ed0d7a)

- `/challenge/update-bisindo-score` error when the user is not logged in
![image](https://github.com/IsyaratKu/isyaratku-backend/assets/87986916/add81019-6cc4-43f6-a108-e233754c6765)
